### PR TITLE
[refactor] header 추가, [feat] 추억 등록 API 연동

### DIFF
--- a/woo-ah-hana-web/next.config.mjs
+++ b/woo-ah-hana-web/next.config.mjs
@@ -2,6 +2,9 @@
 
 const nextConfig = {
   reactStrictMode: false,
+  images: {
+    domains: ['wooahhana-bucket.s3.ap-northeast-2.amazonaws.com'], // S3 버킷 호스트명 추가
+  },
 };
 
 export default nextConfig;

--- a/woo-ah-hana-web/src/app/(..route)/account-log/page.tsx
+++ b/woo-ah-hana-web/src/app/(..route)/account-log/page.tsx
@@ -5,6 +5,7 @@ import Dropdown from "@/app/ui/atom/drop-down/drop-down";
 import TransferList from "@/app/ui/components/account/transfer-list";
 import Bankbook from "@/app/ui/components/bankbook";
 import { useEffect, useState } from "react";
+import Header from "@/app/ui/components/header";
 
 export default function AccountLog() {
   const [transfers, setTransfers] = useState<Transfer[]>([]);
@@ -20,7 +21,10 @@ export default function AccountLog() {
   }, [community, period]);
 
   return (
+      <>
+      <Header title='모임통장 거래내역' link='/home' />
       <div className="p-5 flex flex-col gap-5">
+
         <Bankbook
             title={community.name}
             accountNumber={community.accountNumber}
@@ -32,5 +36,6 @@ export default function AccountLog() {
         </div>
         <TransferList transfers={transfers}/>
       </div>
+      </>
   );
 }

--- a/woo-ah-hana-web/src/app/(..route)/community-register/account-auth/check/page.tsx
+++ b/woo-ah-hana-web/src/app/(..route)/community-register/account-auth/check/page.tsx
@@ -57,7 +57,11 @@ export default function AccountAuthCheck() {
 
     if (response.isSuccess) {
       router.push('/community-register/complete');
-    } else {
+    }
+    else if(response.data == '입금자명이 일치하지 않습니다.') {
+      alert('입금자명이 일치하지 않습니다.');
+    }
+    else {
       alert('모임 계좌 생성에 실패했습니다. 다시 시도해주세요.');
     }
   };

--- a/woo-ah-hana-web/src/app/(..route)/community-register/account-auth/check/page.tsx
+++ b/woo-ah-hana-web/src/app/(..route)/community-register/account-auth/check/page.tsx
@@ -6,6 +6,7 @@ import TextInput from '@/app/ui/atom/text-input/text-input';
 import Header from '@/app/ui/components/header';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
+import {message} from "antd";
 
 export default function AccountAuthCheck() {
   const router = useRouter();
@@ -18,6 +19,7 @@ export default function AccountAuthCheck() {
     validationCode: '',
   });
   const [isFormValid, setIsFormValid] = useState(false);
+  const [messageApi, contextHolder] = message.useMessage();
 
   useEffect(() => {
     const params = {
@@ -59,14 +61,24 @@ export default function AccountAuthCheck() {
       router.push('/community-register/complete');
     }
     else if(response.data == '입금자명이 일치하지 않습니다.') {
-      alert('입금자명이 일치하지 않습니다.');
+      messageApi.open({type: 'error',
+        content: '입력 코드가 일치하지 않습니다.',
+        duration: 3,
+        className: 'font-bold'
+      });
     }
     else {
-      alert('모임 계좌 생성에 실패했습니다. 다시 시도해주세요.');
+      messageApi.open({type: 'error',
+        content: '모임 계좌 생성에 실패했습니다. 다시 시도해주세요.',
+        duration: 3,
+        className: 'font-bold'
+      });
     }
   };
 
   return (
+    <>
+      {contextHolder}
     <div className='h-full flex flex-col'>
       <Header title='모임통장 추가하기' link='/community-register/form' />
       <div className='h-full p-10 flex flex-col justify-between'>
@@ -95,5 +107,6 @@ export default function AccountAuthCheck() {
         </AchromaticButton>
       </div>
     </div>
-  );
+    </>
+    );
 }

--- a/woo-ah-hana-web/src/app/(..route)/community-register/account-auth/page.tsx
+++ b/woo-ah-hana-web/src/app/(..route)/community-register/account-auth/page.tsx
@@ -49,7 +49,6 @@ export default function AccountRegisterForm() {
 
       // 계좌로 1원 보내기 API
       const response = await validateAccount(requestBody);
-
       if (response.isSuccess) {
         const queryParams = new URLSearchParams({
           communityName: formData.communityName,

--- a/woo-ah-hana-web/src/app/(..route)/memory/detail/page.tsx
+++ b/woo-ah-hana-web/src/app/(..route)/memory/detail/page.tsx
@@ -50,11 +50,14 @@ export default async function Home({
             />
           ))
         ) : (
-          <div>데이터가 존재하지 않습니다.</div>
+            <div className="flex flex-col h-40 justify-center items-center">
+                <span className="my-3">아직 남긴 추억이 없어요.</span>
+                <span className="my-3">첫 추억을 남겨보세요!</span>
+            </div>
         )}
       </div>
-      <div className="fixed bottom-5 right-5 mb-5 flex justify-end items-end">
-        <MemoryPostModal planId={planId} />
+        <div className="fixed bottom-5 right-5 mb-5 flex justify-end items-end">
+        <MemoryPostModal planId={planId}/>
       </div>
     </main>
   );

--- a/woo-ah-hana-web/src/app/(..route)/memory/page.tsx
+++ b/woo-ah-hana-web/src/app/(..route)/memory/page.tsx
@@ -3,6 +3,7 @@ import { getCompletedPlans } from "@/app/business/memory/memory.service";
 import AchromaticButton from "@/app/ui/atom/button/achromatic-button";
 import { IoAdd } from "react-icons/io5";
 import Link from "next/link";
+import Header from "@/app/ui/components/header";
 
 export default async function Home({
   searchParams,
@@ -36,6 +37,7 @@ export default async function Home({
   return (
     <main>
       <div className="h-full flex flex-col">
+        <Header title='지난 모임 추억' link='/home' />
         <div className="flex-1 overflow-y-auto p-5">
           <div className="grid grid-rows-1 gap-3">
             {plans ? PlansView : <div>데이터가 존재하지 않습니다.</div>}

--- a/woo-ah-hana-web/src/app/(..route)/plan/detail/page.tsx
+++ b/woo-ah-hana-web/src/app/(..route)/plan/detail/page.tsx
@@ -7,6 +7,7 @@ import { getActivePlans } from "@/app/business/plan/active-plan.service";
 import { ActivePlan } from "@/app/business/plan/active-plan";
 import { Card } from "@/app/ui/molecule/card/card";
 import { getCommunityMembers, Member } from "@/app/business/community/community.service";
+import Header from "@/app/ui/components/header";
 
 export default async function Home({searchParams}:{searchParams: { [key: string]: string | string[] | undefined }}){
   const planId = searchParams.id as string;
@@ -52,6 +53,7 @@ export default async function Home({searchParams}:{searchParams: { [key: string]
   
   return (
     <main>
+      <Header title='모임 일정' link={`/plan?id=${communityId}`} />
       <div className="flex flex-col gap-3 p-5">
         <PlanDetail 
         id={planId} 

--- a/woo-ah-hana-web/src/app/(..route)/plan/page.tsx
+++ b/woo-ah-hana-web/src/app/(..route)/plan/page.tsx
@@ -32,7 +32,7 @@ export default async function Home({
   return (
     <main>
       <div className='h-full flex flex-col'>
-      <Header title='모임 결산' link='/home' />
+      <Header title='모임 일정' link='/home' />
         <div className='flex-1 overflow-y-auto p-5'>
           <div className='grid grid-rows-1 gap-3'>
             {/* TODO: 데이터가 존재하지 않을 경우 ui 수정 */}

--- a/woo-ah-hana-web/src/app/(..route)/plan/set/layout.tsx
+++ b/woo-ah-hana-web/src/app/(..route)/plan/set/layout.tsx
@@ -1,5 +1,11 @@
 import { PlanProvider } from "@/app/context/plan-context";
+import Header from "@/app/ui/components/header";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return <PlanProvider>{children}</PlanProvider>;
+  return (
+      <>
+        <Header title='모임 일정 생성' link='/home'/>
+        <PlanProvider>{children}</PlanProvider>;
+      </>
+  )
 }

--- a/woo-ah-hana-web/src/app/business/community/community.service.ts
+++ b/woo-ah-hana-web/src/app/business/community/community.service.ts
@@ -247,13 +247,13 @@ export async function createCommunity(requestBody: CreateCommunityRequestDTO): P
       data: response.data as string
     }
     }
-catch (error) {
-    console.error(error);
-    return {
-      isSuccess: false,
-      isFailure: true,
-      data: undefined
-    };
+  catch (error) {
+      console.error(error);
+      return {
+        isSuccess: false,
+        isFailure: true,
+        data: error.response.data
+      };
   }
 }
 

--- a/woo-ah-hana-web/src/app/business/memory/memory.service.ts
+++ b/woo-ah-hana-web/src/app/business/memory/memory.service.ts
@@ -203,9 +203,10 @@ export async function createPost(
 
   const requestData = {
     planId: id,
-    memberId: "408466ce-f244-4830-a86d-88d62a1601c8",
+    //memberId: "408466ce-f244-4830-a86d-88d62a1601c8",
     description: content,
-    createAt: new Date().toISOString(),
+    //createAt: new Date().toISOString(),
+    //createAt: "2025-01-30T12:42:37.969Z"
   };
 
   const multipartFormData = new FormData();
@@ -213,7 +214,10 @@ export async function createPost(
     "data",
     new Blob([JSON.stringify(requestData)], { type: "application/json" })
   );
+  //multipartFormData.append("data", JSON.stringify(requestData));
   multipartFormData.append("image", image);
+
+  console.log(multipartFormData);
 
   try {
     const response = await instance.post(
@@ -223,6 +227,11 @@ export async function createPost(
         headers: {
           "Content-Type": "multipart/form-data",
         },
+        transformRequest: [
+          function () {
+            return multipartFormData;
+          },
+        ],
       }
     );
 
@@ -237,7 +246,7 @@ export async function createPost(
       throw new Error("Unexpected server response");
     }
   } catch (error: any) {
-    console.error("Error creating post:", error);
+    //console.error("Error creating post:", error);
     if (error.response?.status === 500) {
       throw new InternetServerError({
         message: "서버가 불안정합니다. 잠시 후 다시 시도해주세요.",

--- a/woo-ah-hana-web/src/app/ui/components/memory/memory-detail.tsx
+++ b/woo-ah-hana-web/src/app/ui/components/memory/memory-detail.tsx
@@ -36,7 +36,15 @@ export function MemoryDetail({
             <div className="text-base mt-2">{date}</div>
           </div>
         </div>
-        <div className=" h-52 bg-red-100">이미지{`# ${imageUrl}`}</div>
+        <div className="bg-red-100 rounded-lg">
+          <Image
+            src={imageUrl}
+            alt={"추억 이미지"}
+            width={500}
+            height={500}
+
+            className="mb-3 rounded-lg"/>
+        </div>
         <div className="flex flex-row justify-between">
           <div className="text-lg">{description}</div>
           <Form

--- a/woo-ah-hana-web/src/app/ui/components/memory/memory-post.modal.tsx
+++ b/woo-ah-hana-web/src/app/ui/components/memory/memory-post.modal.tsx
@@ -13,6 +13,7 @@ import { useState } from "react";
 import { FormTextArea } from "../../molecule/form/form-textarea";
 import { FormImage } from "../../molecule/form/form-image";
 import { createPost } from "@/app/business/memory/memory.service";
+import {message} from "antd";
 
 interface MemoryPostModalProps {
   planId: string;
@@ -21,9 +22,11 @@ interface MemoryPostModalProps {
 export default function MemoryPostModal({ planId }: MemoryPostModalProps) {
   const [content, setContent] = useState<string>("");
   const [imageFile, setImageFile] = useState<File | null>(null);
+  const [messageApi, contextHolder] = message.useMessage();
 
   return (
     <Dialog>
+      {contextHolder}
       <DialogTrigger asChild>
         <AchromaticButton className="h-14 w-14 rounded-full">
           <MdOutlineAddPhotoAlternate color="white" size={40} />
@@ -42,8 +45,14 @@ export default function MemoryPostModal({ planId }: MemoryPostModalProps) {
             }}
             failMessageControl="alert"
             onSuccess={() => {
-              alert("게시되었습니다.");
-              window.location.reload();
+              //alert("게시되었습니다.");
+              messageApi.open({type: 'success',
+                content: '게시되었습니다!',
+                duration: 2,
+                className: 'font-bold'
+              });
+              setTimeout(() => window.location.reload(), 2000);
+
             }}
           >
             <input


### PR DESCRIPTION
- header 추가 : 내/모임 계좌관리, 모임 일정 둘러보기, 지난 모임 추억에 추가
- 모임 생성에 antd/message 적용 : 인증코드(입금자명)이 일치하지 않을 때 알림 팝업
- 추억 등록 : 사진 등록까지 구현 확인, 추억 등록 성공시 antd/message 알림 팝업