### PR TITLE
[ui] 모임, 추억, 회비 입금 현황 minor 수정

### DIFF
--- a/woo-ah-hana-web/src/app/(..route)/ai/layout.tsx
+++ b/woo-ah-hana-web/src/app/(..route)/ai/layout.tsx
@@ -8,10 +8,7 @@ export default function Layout({
   }>){
   return(
     <main>
-      <div className="h-1/6">
-        <div className="px-5 mt-5"><Link href={"/home"}>{'<'}</Link>{' '}{` AI 계획 세우기`}</div>
-      </div>
-      <div className="h-5/6">
+      <div>
         {children}
       </div>
     </main>

--- a/woo-ah-hana-web/src/app/(..route)/ai/page.tsx
+++ b/woo-ah-hana-web/src/app/(..route)/ai/page.tsx
@@ -1,6 +1,7 @@
 import { getPlan } from "@/app/business/plan/plan.service";
 import { RequestActivePlanForm } from "@/app/ui/components/active-plan/requset-active-plan-form";
 import { Card } from "@/app/ui/molecule/card/card";
+import Header from "@/app/ui/components/header";
 
 export default async function Home({
     searchParams,
@@ -9,13 +10,17 @@ export default async function Home({
   }){
   const response = await getPlan(searchParams.plan as string);
   const plan = response.data;
+  const communityId = searchParams.community as string;
+  const planId = searchParams.plan as string;
+
   return (
   <main>
+    <Header title='AI 계획 세우기' link={`/plan/detail?community=${communityId}&id=${planId}`}/>
     <div className="flex flex-col gap-3 p-5"> 
       <Card className="flex flex-col gap-2 p-5 text-center">
-        <div> 여행 계획 짜주는 AI입니다. </div>
+        <div> 여행 계획을 세워주는 AI입니다. </div>
         <div> 음성 또는 키보드로 요청사항을 입력하세요. </div>
-        <div> AI 요청은 하루에 세번까지만 가능합니다. </div>
+        <div> AI 요청은 하루에 3회까지만 가능합니다. </div>
       </Card>
       <RequestActivePlanForm 
         planId={searchParams.plan as string}

--- a/woo-ah-hana-web/src/app/(..route)/fee-status/page.tsx
+++ b/woo-ah-hana-web/src/app/(..route)/fee-status/page.tsx
@@ -1,6 +1,12 @@
 import { getCommunityFeeStatus, MemberFeeStatus } from '@/app/business/community/community.service';
 import { UnpaidMemberList } from '@/app/ui/components/fee-status/unpaid-members';
 import { PaidMemberList } from '@/app/ui/components/fee-status/paid-members';
+import Header from "@/app/ui/components/header";
+
+export interface yearMonthProps {
+  year: number;
+  month: number;
+}
 
 export default async function Home({
   searchParams,
@@ -13,12 +19,21 @@ export default async function Home({
   const paidMembers = communityFeeStatus?.paidMembers as MemberFeeStatus[];
   const unpaidMembers = communityFeeStatus?.unpaidMembers as MemberFeeStatus[];
   const totalMembers = paidMembers.concat(unpaidMembers);
+  const currentDate = new Date();
+
+  const yearMonth : yearMonthProps = {
+    year: currentDate.getFullYear(),
+    month: currentDate.getMonth() + 1
+  };
 
   return (
+      <>
+      <Header title='회비 입금 현황' link='/home' />
     <div className='p-5 flex flex-col gap-8'>
-      <UnpaidMemberList unpaidMembers={unpaidMembers}/>
+      <UnpaidMemberList unpaidMembers={unpaidMembers} yearMonth={yearMonth} />
       <hr></hr>
       <PaidMemberList members={totalMembers}/>
     </div>
+      </>
   );
 }

--- a/woo-ah-hana-web/src/app/(..route)/memory/page.tsx
+++ b/woo-ah-hana-web/src/app/(..route)/memory/page.tsx
@@ -13,7 +13,6 @@ export default async function Home({
   const communityId =
     (searchParams.id as string) || "a61f6270-974b-44f3-b9f3-7a8ab9b145ff";
 
-  console.log(communityId);
   const getPlansResponse = await getCompletedPlans(communityId);
   const plans = getPlansResponse.data;
   console.log(plans);

--- a/woo-ah-hana-web/src/app/business/memory/memory.service.ts
+++ b/woo-ah-hana-web/src/app/business/memory/memory.service.ts
@@ -133,17 +133,18 @@ export async function getPlanReceipt(
 
   try {
     const data: GetPlanReceiptDto = response.data;
+    console.log(response.data);
     const logs = data.records.map(
       (log: any) =>
         new PaymentLog(
-          log.tran_date,
-          log.tran_time,
-          log.inout_type,
-          log.tran_type,
-          log.print_content,
-          log.tran_amt,
-          log.after_balance_amt,
-          log.branch_name
+          log.tranDate,
+          log.tranTime,
+          log.inoutType,
+          log.tranType,
+          log.printContent,
+          log.tranAmt,
+          log.afterBalanceAmt,
+          log.branchMame
         )
     );
 

--- a/woo-ah-hana-web/src/app/ui/components/fee-status/paid-members.tsx
+++ b/woo-ah-hana-web/src/app/ui/components/fee-status/paid-members.tsx
@@ -9,7 +9,7 @@ interface MemberListProps{
 export function PaidMemberList({members}:MemberListProps){
   return(
     <div className='flex flex-col justify-center items-start'>
-    <div className='text-[18px] mb-4'>모임 멤버</div>
+    <div className='text-[18px] mb-4'>이번 달 납입 금액</div>
     {members.map((member, index) => (
       <div
         key={index}
@@ -23,7 +23,7 @@ export function PaidMemberList({members}:MemberListProps){
           />
           <div>{member.memberName}</div>
         </div>
-        <div><span className='text-[19px]'>{member.amount}</span> 원</div>
+        <div><span className='text-[19px]'>{member.amount.toLocaleString()}</span> 원</div>
       </div>
     ))}
   </div>

--- a/woo-ah-hana-web/src/app/ui/components/fee-status/unpaid-members.tsx
+++ b/woo-ah-hana-web/src/app/ui/components/fee-status/unpaid-members.tsx
@@ -3,32 +3,35 @@ import Image from "next/image"
 import ProfileImage from '@/app/assets/img/profile.jpg'
 import { MemberFeeStatus } from "@/app/business/community/community.service";
 import AchromaticButton from "../../atom/button/achromatic-button";
+import {yearMonthProps} from "@/app/(..route)/fee-status/page";
 
 interface UnpaidMemberListProps{
-  unpaidMembers:MemberFeeStatus[]
+  unpaidMembers:MemberFeeStatus[];
+  yearMonth:yearMonthProps;
 }
 
-export function UnpaidMemberList({unpaidMembers}:UnpaidMemberListProps){
+export function UnpaidMemberList({unpaidMembers, yearMonth}:UnpaidMemberListProps){
   
   return (
-    <div className='flex flex-col justify-center items-start'>
-      <div className='text-[18px] mb-4'>안 낸 멤버</div>
-    {unpaidMembers.map((member, index) => (
-      <div
-        key={index}
-        className='flex items-center justify-between gap-6 p-2 w-full'
-      >
-        <div className='flex justify-center items-center gap-8'>
-          <Image
-            src={ProfileImage}
-            alt={`${member.memberName} 프로필`}
-            className='w-12 h-12 rounded-full object-cover'
-          />
-          <div className='text-gray-800'>{member.memberName}</div>
-        </div>
-        <AchromaticButton>회비 요청</AchromaticButton>
+      <div className='flex flex-col justify-center items-start'>
+          <div className='text-[18px] mb-4 font-bold'>{yearMonth.year}년 {yearMonth.month}월 </div>
+          <div className='text-[18px] mb-4'>이번 달 납입 잊지 마세요!</div>
+          {unpaidMembers.map((member, index) => (
+              <div
+                  key={index}
+                  className='flex items-center justify-between gap-6 p-2 w-full'
+              >
+                  <div className='flex justify-center items-center gap-8'>
+                      <Image
+                          src={ProfileImage}
+                          alt={`${member.memberName} 프로필`}
+                          className='w-12 h-12 rounded-full object-cover'
+                      />
+                      <div className='text-gray-800'>{member.memberName}</div>
+                  </div>
+                  <AchromaticButton>회비 요청</AchromaticButton>
+              </div>
+          ))}
       </div>
-    ))}
-  </div>
   )
 }

--- a/woo-ah-hana-web/src/app/ui/components/memory/memory-list-item.tsx
+++ b/woo-ah-hana-web/src/app/ui/components/memory/memory-list-item.tsx
@@ -25,7 +25,8 @@ export function MemoryListItem({
 }: PlanListItemProps) {
   const iconSrc = categoryIcons[category];
   const bgColor = categoryColors[category];
-  console.log(memberNames);
+  console.log(startDate);
+  console.log(endDate);
   return (
     <main>
       <Link href={`memory/detail?id=${planId}`}>
@@ -35,7 +36,7 @@ export function MemoryListItem({
           </div>
           <div className="grid grid-cols-1">
             <p className="text-base mt-2">
-              <strong>{title}</strong>
+              <span className="[word-break:keep-all]">{title}</span>
             </p>
             <p className="text-sm text-slate-500">{`# ${category}`}</p>
           </div>
@@ -44,7 +45,8 @@ export function MemoryListItem({
               <strong>{locations[0]}</strong>
             </p>
             <p className="text-sm text-slate-500">
-              {startDate.substring(5, 10)}~{endDate.substring(5, 10)}
+              {startDate.substring(5, 10) == endDate.substring(5, 10) ?
+                  startDate.substring(5, 10)  : `${startDate.substring(5, 10)}부터 ${endDate.substring(5, 10)}까지`}
             </p>
           </div>
         </Card>

--- a/woo-ah-hana-web/src/app/ui/components/memory/memory-plan.tsx
+++ b/woo-ah-hana-web/src/app/ui/components/memory/memory-plan.tsx
@@ -31,7 +31,7 @@ export function MemoryPlan({
         <p className="text-sm text-gray-500">{date}</p>
       </div>
 
-      <div className="flex flex-wrap gap-2 flex-row">
+      <div className="flex flex-wrap gap-1 flex-row">
         {memberNames.map((name, index) => (
           <span
             key={index}
@@ -42,11 +42,11 @@ export function MemoryPlan({
         ))}
       </div>
 
-      <div className="mt-2">
+      <div className="flex flex-wrap gap-1 flex-row mt-2">
         {locations.map((location, index) => (
           <span
             key={index}
-            className={`px-3 py-1 bg-wooahPurple text-wooahDeepPurple rounded-full text-lg mr-1`}
+            className={`px-3 py-1 bg-wooahPurple text-wooahDeepPurple rounded-full text-lg mr-1 break-all`}
           >
             {location}
           </span>

--- a/woo-ah-hana-web/src/app/ui/components/memory/memory-plan.tsx
+++ b/woo-ah-hana-web/src/app/ui/components/memory/memory-plan.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import MemoryReceiptModal from "@/app/ui/components/memory/memory-receipt.modal";
+import dayjs from 'dayjs';
 
 export interface PlanListItemProps {
   planId: string;
@@ -22,37 +23,40 @@ export function MemoryPlan({
   communityId,
   memberNames,
 }: PlanListItemProps) {
-  const date = endDate.split(" ")[0];
+    console.log(startDate, endDate);
+    const sdate= startDate.split(" ")[0];
+  const edate = endDate.split(" ")[0];
+  const diff = dayjs(edate).diff(dayjs(sdate), "day");
   console.log(category, startDate, communityId)
   return (
-    <div>
-      <div className="flex justify-between items-center mb-5">
-        <h2 className="text-2xl font-bold">{title}</h2>
-        <p className="text-sm text-gray-500">{date}</p>
-      </div>
-
-      <div className="flex flex-wrap gap-1 flex-row">
-        {memberNames.map((name, index) => (
-          <span
-            key={index}
-            className="px-3 py-1 bg-wooahBlue text-wooahDeepBlue rounded-full text-lg mb-1"
-          >
+      <div>
+          <div className="flex justify-between items-center">
+              <h2 className="text-2xl font-bold">{title}</h2>
+          </div>
+          <p className="text-sm text-gray-500">{
+              sdate == edate ? `${sdate}, 하루`: `${sdate}부터 ${edate}까지, ${diff+1}일`}</p>
+          <div className="flex flex-wrap gap-1 flex-row">
+              {memberNames.map((name, index) => (
+                  <span
+                      key={index}
+                      className="px-3 py-1 bg-wooahBlue text-wooahDeepBlue rounded-full text-lg mb-1"
+                  >
             {name}
           </span>
-        ))}
-      </div>
+              ))}
+          </div>
 
-      <div className="flex flex-wrap gap-1 flex-row mt-2">
-        {locations.map((location, index) => (
-          <span
-            key={index}
-            className={`px-3 py-1 bg-wooahPurple text-wooahDeepPurple rounded-full text-lg mr-1 break-all`}
-          >
+          <div className="flex flex-wrap gap-1 flex-row mt-2">
+              {locations.map((location, index) => (
+                  <span
+                      key={index}
+                      className={`px-3 py-1 bg-wooahPurple text-wooahDeepPurple rounded-full text-lg mr-1 break-all`}
+                  >
             {location}
           </span>
-        ))}
+              ))}
+          </div>
+          <MemoryReceiptModal planId={planId}/>
       </div>
-      <MemoryReceiptModal planId={planId} />
-    </div>
   );
 }

--- a/woo-ah-hana-web/src/app/ui/components/memory/memory-receipt.modal.tsx
+++ b/woo-ah-hana-web/src/app/ui/components/memory/memory-receipt.modal.tsx
@@ -29,7 +29,7 @@ export default async function MemoryReceiptModal({
         </AchromaticButton>
       </DialogTrigger>
       <DialogContent className="p-6">
-        <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-5">
           <div className="flex justify-between">
             <div className="text-lg font-semibold">영수증</div>
             <DialogClose>
@@ -38,7 +38,7 @@ export default async function MemoryReceiptModal({
           </div>
           <div
             id="scrollableDiv"
-            className="overflow-y-auto max-h-[55vh] border-t border-b border-gray-300 pr-2"
+            className="overflow-y-auto max-h-[54vh] border-t border-b border-gray-300 pr-2"
           >
             <MemoryReceiptDetail logs={receiptData.getRecords()} />
           </div>
@@ -46,12 +46,12 @@ export default async function MemoryReceiptModal({
             <div className="flex justify-between w-full">
               <div>전체 소비 금액</div>
               <div className="font-semibold">
-                {receiptData.getTotalAmt()} 원
+                {receiptData.getTotalAmt().toLocaleString('ko-KR')} 원
               </div>
             </div>
             <div className="flex justify-between w-full">
               <div>인당 소비 금액</div>
-              <div className="font-semibold">{receiptData.getPerAmt()} 원</div>
+              <div className="font-semibold">{receiptData.getPerAmt().toLocaleString('ko-KR')} 원</div>
             </div>
           </div>
         </div>

--- a/woo-ah-hana-web/src/app/ui/components/plan/date-detail.modal.tsx
+++ b/woo-ah-hana-web/src/app/ui/components/plan/date-detail.modal.tsx
@@ -8,6 +8,7 @@ import {
 import Form from "../../molecule/form/form-index";
 import { updatePlanDate } from "@/app/business/plan/plan-update.service";
 import { FormSubmitButton } from "../../molecule/form/form-submit-button";
+import {message} from "antd";
 
 interface DateDetailDilogProps {
   id: string;
@@ -17,8 +18,11 @@ export function DateDetailDilog({
   id,
 }: DateDetailDilogProps) {
   // TODO: FormData 활용해서 날짜 업데이트 api 요청
+  const [messageApi, contextHolder] = message.useMessage();
+
   return (
     <Dialog>
+      {contextHolder}
       <DialogTrigger asChild>
         <AchromaticButton variant={"ghost"} className="text-slate-600">
           수정
@@ -27,7 +31,15 @@ export function DateDetailDilog({
       <DialogContent title="모임일정 변경">
         <hr></hr>
         <div className="p-5 text-center">
-          <Form id="updatedate" action={updatePlanDate} failMessageControl={"alert"}>
+          <Form id="updatedate" action={updatePlanDate} failMessageControl={"alert"}
+                onSuccess={() => {
+                  messageApi.open({type: 'success',
+                    content: '일정 변경에 성공했습니다!',
+                    duration: 1,
+                    className: 'font-bold'
+                  });
+                  setTimeout(() => window.location.reload(), 1000);
+                }}>
             <Form.TextInput value={id} id='id' className="hidden" placeholder=""/>
             <div className="grid grid-cols-1 gap-2 text-lg text-slate-500">
               <div className="grid grid-cols-[2fr_4fr]">

--- a/woo-ah-hana-web/src/app/ui/components/plan/locations-detail.modal.tsx
+++ b/woo-ah-hana-web/src/app/ui/components/plan/locations-detail.modal.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { FormState } from "../../molecule/form/form-root";
 import Form from "../../molecule/form/form-index";
 import { updateLocations } from "@/app/business/plan/plan-update.service";
+import {message} from "antd";
 
 interface LocationsDetailDilogProps{
   id: string,
@@ -13,6 +14,7 @@ interface LocationsDetailDilogProps{
 
 export function LocationsDetailDilog({id, locations}: LocationsDetailDilogProps){
   const [currentLocations, setCurrentLocations] = useState<string[]>(locations);
+  const [messageApi, contextHolder] = message.useMessage();
 
   function handleAddLocation(prevState: FormState, formData: FormData):FormState{
     try{
@@ -44,6 +46,7 @@ export function LocationsDetailDilog({id, locations}: LocationsDetailDilogProps)
   
   return (
     <Dialog>
+      {contextHolder}
       <DialogTrigger asChild>
         <AchromaticButton variant={'ghost'} className="text-slate-600">수정</AchromaticButton>
       </DialogTrigger>
@@ -72,7 +75,13 @@ export function LocationsDetailDilog({id, locations}: LocationsDetailDilogProps)
           </div>
           <AchromaticButton onClick={async()=>{
             await updateLocations(id, currentLocations)
-            alert('모임 장소가 변경되었습니다!')
+            messageApi.open({
+              type: 'success',
+              content: '모임 장소 변경에 성공했습니다!',
+              duration: 1,
+              className: 'font-bold'
+            });
+              setTimeout(() => window.location.reload(), 1000);
             }}>변경하기</AchromaticButton>
         </div>
       </DialogContent>

--- a/woo-ah-hana-web/src/app/ui/components/plan/member-detail.modal.tsx
+++ b/woo-ah-hana-web/src/app/ui/components/plan/member-detail.modal.tsx
@@ -4,6 +4,7 @@ import { updateMembers } from "@/app/business/plan/plan-update.service";
 import AchromaticButton from "@/app/ui/atom/button/achromatic-button";
 import { Dialog, DialogContent, DialogTrigger } from "@/app/ui/molecule/dialog/dialog";
 import { useEffect, useState } from "react";
+import {message} from "antd";
 
 interface MemberDetailDilogProps{
   id: string,
@@ -16,6 +17,7 @@ interface MemberDetailDilogProps{
 export function MemberDetailDilog({id, memberIds, memberNames, communityMemberIds, communityMemberNames}: MemberDetailDilogProps){
   const [planMembers, setPlanMembers] = useState<Member[]>([]);
   const [communityMembers, setCommunityMembers] = useState<Member[]>([]);
+  const [messageApi, contextHolder] = message.useMessage();
 
   function handleAddMember(addedMember: Member){
     const members = [addedMember, ...planMembers]
@@ -33,7 +35,15 @@ export function MemberDetailDilog({id, memberIds, memberNames, communityMemberId
 
   async function handleUpdateMember(){
     const memberIds = planMembers.map((member)=>{return member.id});
-    await updateMembers(id, memberIds).then(()=>{alert("참여 멤버가 변경되었어요!")})
+    await updateMembers(id, memberIds).then(()=> {
+      messageApi.open({
+        type: 'success',
+        content: '참여 멤버 변경에 성공했습니다!',
+        duration: 1,
+        className: 'font-bold'
+      });
+      setTimeout(() => window.location.reload(), 1000);
+    });
   };
 
   useEffect(()=>{
@@ -59,6 +69,7 @@ export function MemberDetailDilog({id, memberIds, memberNames, communityMemberId
 
   return (
     <Dialog>
+      {contextHolder}
       <DialogTrigger asChild>
         <AchromaticButton variant={'ghost'} className="text-slate-600">수정</AchromaticButton>
       </DialogTrigger>

--- a/woo-ah-hana-web/src/app/ui/components/plan/plan-list-item.tsx
+++ b/woo-ah-hana-web/src/app/ui/components/plan/plan-list-item.tsx
@@ -45,7 +45,8 @@ export function PlanListItem({
 
               <div className='flex flex-col justify-center items-start gap-4 py-2'>
               <div className='flex flex-col gap-3 text-slate-700 text-[17px]'>
-                <div className=''>{startDate.substring(5, 10)} ~ {endDate.substring(5, 10)}</div>
+                <div className=''>{startDate.substring(5, 10) == endDate.substring(5, 10) ?
+                    startDate.substring(5, 10)  : `${startDate.substring(5, 10)}부터 ${endDate.substring(5, 10)}까지`}</div>
               </div>
                 <div className='text-xl'>
                   <strong>{title}</strong>


### PR DESCRIPTION
- ai 부분 문구 수정 / 뒤로 가기 헤더 추가
![image](https://github.com/user-attachments/assets/d73a3b86-eacc-4f04-8f21-9d67e21abd72)
- 모임 정보 수정 성공시 antd/message 호출 후 modal 꺼지도록 수정

- 회비 입금 현황에 헤더 추가, 년/월 표시 및 문구 수정 -> 문구는 더 적절한 것이 있는지? 있다면 수정 부탁
![image](https://github.com/user-attachments/assets/708f4d4c-ec57-4225-bb0f-002a09a915f4)
- 모임 계획 날짜 표시 형식을 'mm-dd ~ mm-dd' 에서 'mm-dd부터 mm-dd'까지로 수정해 봄, 당일치기 시 mm-dd만 표시
- 모임명이 긴 경우 줄바꿈시 단어가 잘리는 문제 해결
![image](https://github.com/user-attachments/assets/65fb302d-5f35-4854-a7e2-e5be6bdcc20b)

- 영수증 정상적으로 표시되게 dto의 key명을 수정(snake -> camel)
- 추억에서 모임 일정을 표시하도록 수정
![image](https://github.com/user-attachments/assets/f5de5bdb-c25f-4074-83f7-5fec02b3059d)
![image](https://github.com/user-attachments/assets/5b9a5dec-3e4f-4d07-bd76-4a2371c6ee6c)
