### PR TITLE
[refactor] Bankbook에 색상 props 속성 추가

### DIFF
--- a/woo-ah-hana-web/src/app/(..route)/account-log/page.tsx
+++ b/woo-ah-hana-web/src/app/(..route)/account-log/page.tsx
@@ -29,6 +29,8 @@ export default function AccountLog() {
             title={community.name}
             accountNumber={community.accountNumber}
             balance={transfers.length==0?0:transfers[0].afterBalanceAmt as unknown as number}
+            bgcolor={'wooahMain'}
+            bdcolor={'wooahMain'}
             footer={<div></div>}
         />
         <div className="flex justify-end">

--- a/woo-ah-hana-web/src/app/(..route)/home/page.tsx
+++ b/woo-ah-hana-web/src/app/(..route)/home/page.tsx
@@ -46,6 +46,8 @@ export default async function Home({searchParams}:{searchParams: { [key: string]
             title={communityAccount.name}
             accountNumber={communityAccount.accountNumber}
             balance={communityAccount.balance as unknown as number}
+            bdcolor={'wooahMain'}
+            bgcolor={'wooahMain'}
             footer={<div className='w-full text-sm text-right'>거래내역 조회 {`>`} </div>}
           />
         </Link>

--- a/woo-ah-hana-web/src/app/ui/components/account-management/account-management-main.tsx
+++ b/woo-ah-hana-web/src/app/ui/components/account-management/account-management-main.tsx
@@ -19,6 +19,8 @@ export function AccountManagementMain({bankName, accountNumber, accountBalance, 
         title={bankName}
         accountNumber={accountNumber}
         balance={accountBalance}
+        bgcolor={'wooahBrightPurple'}
+        bdcolor={'wooahBrightPurple'}
         footer={
           <div className="w-[100%] flex justify-between">
             <AutoTransferDialog accountNumber={accountNumber} fee={fee} feePeriod={feePeriod}/>

--- a/woo-ah-hana-web/src/app/ui/components/bankbook.tsx
+++ b/woo-ah-hana-web/src/app/ui/components/bankbook.tsx
@@ -5,18 +5,19 @@ type Props = {
   title: string;
   accountNumber: string;
   balance: number;
+  bgcolor: string;
+  bdcolor: string;
   footer?: React.ReactNode;
 };
 
-export default function Bankbook({ title, accountNumber, balance, footer }: Props) {
+export default function Bankbook({ title, accountNumber, balance, bgcolor, bdcolor, footer }: Props) {
   const formattedBalance =(typeof balance === 'number')? balance.toLocaleString():balance;
-
   return (
     <Card
       style={{
         boxShadow: '2px 5px 8px rgba(0, 0, 0, 0.4)',
       }}
-      className='bg-wooahMain text-white border-wooahMain'
+      className={`text-white bg-${bgcolor || ''} border-${bdcolor || ''}`}
     >
       <div className='flex justify-between'>
         <CardHeader>{title}</CardHeader>

--- a/woo-ah-hana-web/tailwind.config.ts
+++ b/woo-ah-hana-web/tailwind.config.ts
@@ -55,6 +55,7 @@ export default {
         wooahDeepYellow: "#7D8B2F",
         wooahDeepPurple: "#AC38DD",
         wooahDeepMint: "#1892B0",
+        wooahBrightPurple: "#6976ec",
       },
       borderRadius: {
         "tremor-small": "0.375rem",


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/42144932-9d0c-4c7a-9b5c-864d08b3f445)
![image](https://github.com/user-attachments/assets/9171cee1-0122-4602-b6c6-bcaa0bcb2940)
Bankbook card 컴포넌트의 색상 지정
모임통장 / 개인통장 색상 살짝 다르게 수정, 다시 둘 다 동일하게 원복 가능